### PR TITLE
:recycle: refactor(api, utils): replace hash-wasm with crc-32

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@vueuse/core": "^10.7.2",
 		"axios": "^1.6.7",
 		"cookie-parser": "^1.4.6",
+		"crc-32": "^1.2.2",
 		"hash-wasm": "^4.11.0",
 		"jquery": "^3.7.1",
 		"localforage": "^1.10.0",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,7 +1,6 @@
 import request from "@/utils/request.js";
 
 import {LRUCache} from 'lru-cache';
-import {createCRC32} from "hash-wasm";
 
 const nil = (args) => args;
 

--- a/src/utils/ssr.js
+++ b/src/utils/ssr.js
@@ -1,12 +1,9 @@
-import {createCRC32} from "hash-wasm";
 import {useServerSideRenderStore} from "@/stores/ssr.js";
 import {useId} from "vue-unique-ssr-id";
-
-const crc32Instance = (await createCRC32());
+import CRC32 from "crc-32";
 
 export function getReqId(params = {}) {
-    // noinspection JSCheckFunctionSignatures
-    return crc32Instance.init().update(JSON.stringify(params)).digest('hex', null);
+    return CRC32.str(JSON.stringify(params)).toString(16);
 }
 
 


### PR DESCRIPTION
- Remove hash-wasm dependency from api.js and ssr.js
- Use crc-32 library to generate request ids
- Add crc-32 dependency to package.json